### PR TITLE
Substitute type for mimeType at new Blob()

### DIFF
--- a/src/BlobBuffer.js
+++ b/src/BlobBuffer.js
@@ -210,7 +210,7 @@
 							result.push(buffer[i].data);
 						}
 						
-						return new Blob(result, {mimeType: mimeType});
+						return new Blob(result, {type: mimeType});
 					});
 				}
 				


### PR DESCRIPTION
Blob has a type attribute not a mimeType attribute https://www.w3.org/TR/FileAPI/#dfn-type